### PR TITLE
Eliminate non python dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,176 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ When `nix-shell` is installed, dependencies should be automatically downloaded o
 
 ## pdfdeanimate-image.py
 
+The dependencies for this script can also be installed via `pip install -r requirements.txt`.
+
 This utility removes the "animation" (step-by-step reveal) slides from a pdf.
 
 - It takes a pdf file that was exported from a presentation.

--- a/pdfdeanimate-image.py
+++ b/pdfdeanimate-image.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i python3 -p poppler_utils pdftk python38 python38Packages.numpy python38Packages.pillow
+#!nix-shell -i python3 -p python38 python38Packages.numpy
 
 import sys
 import numpy
@@ -11,7 +11,6 @@ input_pdf_doc = PdfDocument(input_pdf_path)
 
 lastpix = None
 containpages = []
-currenthold = -1
 
 for page_i, page in enumerate(input_pdf_doc):
     pix = page.render(grayscale=True).to_numpy()

--- a/pdfdeanimate-image.py
+++ b/pdfdeanimate-image.py
@@ -1,53 +1,30 @@
 #!/usr/bin/env nix-shell
 #!nix-shell -i python3 -p poppler_utils pdftk python38 python38Packages.numpy python38Packages.pillow
 
-import subprocess
 import sys
-import os
-import glob
 import numpy
 from pathlib import Path
-from PIL import Image, ImageOps
+from pypdfium2 import PdfDocument
 
-pdffile = Path(sys.argv[1])
-pdffile_name = os.path.splitext(pdffile.name)[0]
-
-pgmdir_name = pdffile.parent/(pdffile_name+"-pgm")
-pgmfile_name = pgmdir_name/pdffile_name
-
-try:
-    os.mkdir(pgmdir_name)
-    subprocess.run(["pdftoppm", "-gray", pdffile, pgmfile_name], stderr=subprocess.DEVNULL)
-    print("converted pdf to pgm files")
-except FileExistsError:
-    print("assuming pdf is already converted to pgm")
-
+input_pdf_path = Path(sys.argv[1])
+input_pdf_doc = PdfDocument(input_pdf_path)
 
 lastpix = None
-haslastpix = False
-
 containpages = []
 currenthold = -1
 
-filelist = glob.glob(os.path.join(pgmdir_name, '*.pgm'))
-for filename in sorted(filelist, key=lambda s: s.lower()):
-    pagenr = filename.rsplit("/",1)[-1].rsplit(".",1)[0].rsplit("-",1)[-1]
+for page_i, page in enumerate(input_pdf_doc):
+    pix = page.render(grayscale=True).to_numpy()
 
-    img = Image.open(filename)
-    pix = numpy.array(img)
-    img.close()
-
-    if haslastpix:
+    if lastpix is not None:
         isconsecutive = numpy.all(lastpix >= pix)
         if not isconsecutive:
-            containpages.append(currenthold)
+            containpages.append(page_i - 1)
 
     lastpix = pix
-    haslastpix = True
-    currenthold = pagenr
+containpages.append(page_i)
 
-containpages.append(currenthold)
-
-print(f"reduced {len(filelist)}-pages pdf to {len(containpages)}-pages pdf")
-output_pdffile = pdffile.parent/("stripped-"+pdffile.name)
-subprocess.run(["pdftk", pdffile, "cat"] + containpages + ["output", output_pdffile])
+print(f"reduced {len(input_pdf_doc)}-pages pdf to {len(containpages)}-pages pdf")
+output_pdf_doc = PdfDocument.new()
+output_pdf_doc.import_pages(input_pdf_doc, containpages)
+output_pdf_doc.save(input_pdf_path.with_name("stripped-" + input_pdf_path.name))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+pypdfium2


### PR DESCRIPTION
# Summary
This uses the `pypdfium2` module to eliminate the non-python module dependencies (`pdftk` and `poppler_utils`) in the [pdfdeanimate-image.py](https://github.com/schokotets/pdf-slides-utils/blob/main/pdfdeanimate-image.py) script and improve performance.

# Benefits
- Makes [pdfdeanimate-image.py](https://github.com/schokotets/pdf-slides-utils/blob/main/pdfdeanimate-image.py) script much easier to set up and use for those who don't use `nix-shell` (can now install dependencies using `pip install -r requirements.txt`).
- Performance of the script significantly improved.
- No longer any need for creating an intermediate folder to store PDF page images.

# Problems
- `pypdfium2` has not yet been packaged for `nix-shell`, so this would have to be installed manually by `nix-shell` users. 