### PR TITLE
Add percentage tolerance argument

### DIFF
--- a/pdfdeanimate-image.py
+++ b/pdfdeanimate-image.py
@@ -1,12 +1,26 @@
 #!/usr/bin/env python3
 
-import sys
-import numpy
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from numpy import mean
 from pathlib import Path
 from pypdfium2 import PdfDocument
 
-input_pdf_path = Path(sys.argv[1])
+parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
+parser.add_argument("input_pdf_path", help="Path of PDF to remove duplicate pages from")
+parser.add_argument(
+    "-t",
+    "--tolerance",
+    default=0,
+    help="Max %% lightened pixels between two pages before considered non-duplicates"
+)
+args = parser.parse_args()
+
+input_pdf_path = Path(args.input_pdf_path)
 input_pdf_doc = PdfDocument(input_pdf_path)
+
+PERCENT_TOLERANCE = float(args.tolerance)
+assert 0 <= PERCENT_TOLERANCE < 100
+PROPORTION_TOLERANCE = PERCENT_TOLERANCE / 100
 
 lastpix = None
 containpages = []
@@ -15,7 +29,7 @@ for page_i, page in enumerate(input_pdf_doc):
     pix = page.render(grayscale=True).to_numpy()
 
     if lastpix is not None:
-        isconsecutive = numpy.all(lastpix >= pix)
+        isconsecutive = mean(pix > lastpix) <= PROPORTION_TOLERANCE
         if not isconsecutive:
             containpages.append(page_i - 1)
 


### PR DESCRIPTION
# Summary

Adds percentage tolerance command line argument specifying the maximum percentage of lightened pixels allowed between duplicate pages.

# Benefits

- Allows ignoring small overlaps caused by enhancements such as arrows so only the enhanced page needs to be included.